### PR TITLE
Add proxy support

### DIFF
--- a/lib/src/settings/settings_dialog.dart
+++ b/lib/src/settings/settings_dialog.dart
@@ -101,6 +101,10 @@ class SettingsDialog extends HookConsumerWidget {
     final textFieldFocusNode = useFocusNode();
     final ignoredDomains =
         useState<List<String>>(List.from(settings.ignoredDomains));
+    final proxyUrl = useState(settings.proxyUrl);
+    final proxyTextFieldController =
+        useTextEditingController(text: proxyUrl.value);
+    final proxyTextFieldFocusNode = useFocusNode();
 
     // Features
     final checkForUpdatesOnStartBox = useState(settings.checkForUpdatesOnStart);
@@ -146,6 +150,7 @@ class SettingsDialog extends HookConsumerWidget {
         assetUrlFontSize: assetUrlFontSize.value,
         ignoredSubfolders: ignoredSubfolders.value,
         ignoredDomains: ignoredDomains.value,
+        proxyUrl: proxyTextFieldController.text.trim(),
       );
 
       if (ref.read(selectedModTypeProvider) == ModTypeEnum.savedObject &&
@@ -264,6 +269,11 @@ class SettingsDialog extends HookConsumerWidget {
                                     textFieldFocusNode: textFieldFocusNode,
                                     numberValue: concurrentDownloadsValue,
                                     ignoredDomains: ignoredDomains,
+                                    proxyTextFieldController:
+                                        proxyTextFieldController,
+                                    proxyTextFieldFocusNode:
+                                        proxyTextFieldFocusNode,
+                                    proxyUrl: proxyUrl,
                                   );
 
                                 case SettingsSection.updateUrlsPresets:
@@ -1020,12 +1030,18 @@ class SettingsNetworkColumn extends StatelessWidget {
     required this.textFieldFocusNode,
     required this.numberValue,
     required this.ignoredDomains,
+    required this.proxyTextFieldController,
+    required this.proxyTextFieldFocusNode,
+    required this.proxyUrl,
   });
 
   final TextEditingController textFieldController;
   final FocusNode textFieldFocusNode;
   final ValueNotifier<int> numberValue;
   final ValueNotifier<List<String>> ignoredDomains;
+  final TextEditingController proxyTextFieldController;
+  final FocusNode proxyTextFieldFocusNode;
+  final ValueNotifier<String> proxyUrl;
 
   @override
   Widget build(BuildContext context) {
@@ -1094,6 +1110,44 @@ class SettingsNetworkColumn extends StatelessWidget {
             values: ignoredDomains.value,
             addLabel: 'Add domain name',
             onChanged: (list) => ignoredDomains.value = list,
+          ),
+          SizedBox(height: 16),
+          Row(
+            children: [
+              const Expanded(
+                child: Row(
+                  spacing: 4,
+                  children: [
+                    Text(
+                      'Proxy URL (optional)',
+                      style: TextStyle(fontSize: 16),
+                    ),
+                    CustomTooltip(
+                      message:
+                          'Enter a proxy URL to route network requests through a proxy server\nFormat: http://proxy.example.com:8080 or socks5://proxy.example.com:1080',
+                      child: Icon(Icons.info_outline),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: 8),
+          TextField(
+            controller: proxyTextFieldController,
+            cursorColor: Colors.black,
+            style: TextStyle(color: Colors.black),
+            decoration: InputDecoration(
+              fillColor: Colors.white,
+              filled: true,
+              border: OutlineInputBorder(),
+              hintText: 'http://proxy.example.com:8080',
+              hintStyle: TextStyle(color: Colors.grey),
+            ),
+            focusNode: proxyTextFieldFocusNode,
+            onChanged: (value) {
+              proxyUrl.value = value;
+            },
           ),
         ],
       ),

--- a/lib/src/state/download/download.dart
+++ b/lib/src/state/download/download.dart
@@ -1,9 +1,10 @@
 import 'dart:convert' show JsonEncoder, json;
-import 'dart:io' show File, FileMode, RandomAccessFile;
+import 'dart:io' show File, FileMode, HttpClient, RandomAccessFile;
 
 import 'package:bson/bson.dart' show BsonBinary, BsonCodec;
 import 'package:dio/dio.dart'
     show BaseOptions, CancelToken, Dio, DioException, DioExceptionType, Options;
+import 'package:dio/io.dart' show IOHttpClientAdapter;
 import 'package:fixnum/fixnum.dart' show Int64;
 import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter/material.dart' show debugPrint;
@@ -48,7 +49,26 @@ class DownloadNotifier extends StateNotifier<DownloadState> {
 
   DownloadNotifier(this.ref)
       : dio = Dio(BaseOptions(connectTimeout: const Duration(seconds: 15))),
-        super(const DownloadState());
+        super(const DownloadState()) {
+    _configureProxy();
+  }
+
+  void _configureProxy() {
+    final proxyUrl = ref.read(settingsProvider).proxyUrl;
+    (dio.httpClientAdapter as IOHttpClientAdapter).createHttpClient = () {
+      final client = HttpClient();
+      if (proxyUrl.isNotEmpty) {
+        client.findProxy = (uri) => 'PROXY $proxyUrl';
+      } else {
+        client.findProxy = null;
+      }
+      return client;
+    };
+  }
+
+  void updateProxySettings() {
+    _configureProxy();
+  }
 
   // MARK: Cancel DL button
   Future<void> handleCancelDownloadsButton() async {

--- a/lib/src/state/settings/settings_state.dart
+++ b/lib/src/state/settings/settings_state.dart
@@ -23,6 +23,7 @@ class SettingsState {
   final double assetUrlFontSize;
   final List<String> ignoredSubfolders;
   final List<String> ignoredDomains;
+  final String proxyUrl;
 
   const SettingsState({
     required this.useModsListView,
@@ -41,6 +42,7 @@ class SettingsState {
     required this.urlReplacementPresets,
     required this.ignoredSubfolders,
     required this.ignoredDomains,
+    this.proxyUrl = '',
   });
 
   factory SettingsState.defaultState() {
@@ -83,6 +85,7 @@ class SettingsState {
       'assetUrlFontSize': assetUrlFontSize,
       'ignoredSubfolders': ignoredSubfolders,
       'ignoredDomains': ignoredDomains,
+      'proxyUrl': proxyUrl,
     };
   }
 
@@ -107,6 +110,7 @@ class SettingsState {
       assetUrlFontSize: _parseDouble(json['assetUrlFontSize'], 12.0),
       ignoredSubfolders: _parseStringList(json['ignoredSubfolders']),
       ignoredDomains: _parseStringList(json['ignoredDomains']),
+      proxyUrl: _parseString(json['proxyUrl'], ''),
     );
   }
 
@@ -178,5 +182,11 @@ class SettingsState {
     if (value is! List) return [];
 
     return value.map((item) => item?.toString()).whereType<String>().toList();
+  }
+
+  static String _parseString(dynamic value, String defaultValue) {
+    if (value == null) return defaultValue;
+    if (value is String) return value;
+    return defaultValue;
   }
 }


### PR DESCRIPTION
Route network requests through a configurable proxy URL. Settings dialog (Network section) gains a Proxy URL field; the value is persisted and applied to the Dio client on startup.

Supports HTTP and SOCKS5 proxy formats, e.g.:
  http://proxy.example.com:8080
  socks5://proxy.example.com:1080