### PR TITLE
Add toggleable debug console

### DIFF
--- a/lib/src/logging/logging_console.dart
+++ b/lib/src/logging/logging_console.dart
@@ -1,0 +1,266 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show Clipboard, ClipboardData;
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tts_mod_vault/src/state/logging/logging_state.dart';
+import 'package:tts_mod_vault/src/state/provider.dart' show loggingProvider;
+
+class LoggingConsole extends HookConsumerWidget {
+  const LoggingConsole({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final loggingState = ref.watch(loggingProvider);
+    final loggingNotifier = ref.read(loggingProvider.notifier);
+    final scrollController = useScrollController();
+    final filterController = useTextEditingController();
+
+    // Auto-scroll to bottom when new logs are added
+    useEffect(() {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (scrollController.hasClients) {
+          scrollController.animateTo(
+            scrollController.position.maxScrollExtent,
+            duration: const Duration(milliseconds: 100),
+            curve: Curves.easeOut,
+          );
+        }
+      });
+      return null;
+    }, [loggingState.entries.length]);
+
+    if (!loggingState.isVisible) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      height: 400,
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.9),
+        border: Border.all(color: Colors.grey.shade600),
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
+      ),
+      child: Column(
+        children: [
+          // Header with controls
+          Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: Colors.grey.shade800,
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
+            ),
+            child: Row(
+              children: [
+                const Icon(Icons.terminal, color: Colors.white, size: 16),
+                const SizedBox(width: 8),
+                const Text(
+                  'Debug Console',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 14,
+                  ),
+                ),
+                const Spacer(),
+                // Level filter buttons
+                Wrap(
+                  spacing: 4,
+                  children: LogLevel.values.map((level) {
+                    final isActive = loggingState.visibleLevels.contains(level);
+                    return FilterChip(
+                      label: Text(
+                        level.name.toUpperCase(),
+                        style: TextStyle(
+                          color: isActive ? Colors.black : Colors.white,
+                          fontSize: 10,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      selected: isActive,
+                      onSelected: (selected) {
+                        final newLevels = Set<LogLevel>.from(loggingState.visibleLevels);
+                        if (selected) {
+                          newLevels.add(level);
+                        } else {
+                          newLevels.remove(level);
+                        }
+                        loggingNotifier.setVisibleLevels(newLevels);
+                      },
+                      backgroundColor: Colors.transparent,
+                      selectedColor: _getLevelColor(level),
+                      side: BorderSide(color: _getLevelColor(level), width: 1),
+                    );
+                  }).toList(),
+                ),
+                const SizedBox(width: 8),
+                // Action buttons
+                IconButton(
+                  icon: const Icon(Icons.copy, color: Colors.white, size: 16),
+                  onPressed: () => _copyLogsToClipboard(loggingState),
+                  tooltip: 'Copy logs to clipboard',
+                ),
+                IconButton(
+                  icon: const Icon(Icons.clear, color: Colors.white, size: 16),
+                  onPressed: loggingNotifier.clearLogs,
+                  tooltip: 'Clear logs',
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close, color: Colors.white, size: 16),
+                  onPressed: loggingNotifier.toggleVisibility,
+                  tooltip: 'Close console',
+                ),
+              ],
+            ),
+          ),
+          // Filter bar
+          Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: Colors.grey.shade900,
+            ),
+            child: TextField(
+              controller: filterController,
+              style: const TextStyle(color: Colors.white, fontSize: 12),
+              decoration: const InputDecoration(
+                hintText: 'Filter logs...',
+                hintStyle: TextStyle(color: Colors.grey),
+                prefixIcon: Icon(Icons.search, color: Colors.grey, size: 16),
+                border: InputBorder.none,
+                contentPadding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              ),
+              onChanged: loggingNotifier.setFilter,
+            ),
+          ),
+          // Log entries
+          Expanded(
+            child: ListView.builder(
+              controller: scrollController,
+              itemCount: loggingState.filteredEntries.length,
+              itemBuilder: (context, index) {
+                final entry = loggingState.filteredEntries[index];
+                return Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Timestamp
+                      Text(
+                        entry.formattedTime,
+                        style: const TextStyle(
+                          color: Colors.grey,
+                          fontSize: 10,
+                          fontFamily: 'monospace',
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      // Level badge
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+                        decoration: BoxDecoration(
+                          color: entry.color,
+                          borderRadius: BorderRadius.circular(3),
+                        ),
+                        child: Text(
+                          entry.levelText,
+                          style: const TextStyle(
+                            color: Colors.black,
+                            fontSize: 9,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      // Category
+                      if (entry.category != null) ...[
+                        Text(
+                          '[${entry.category}]',
+                          style: const TextStyle(
+                            color: Colors.cyan,
+                            fontSize: 11,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(width: 4),
+                      ],
+                      // Message
+                      Expanded(
+                        child: Text(
+                          entry.message,
+                          style: TextStyle(
+                            color: entry.color,
+                            fontSize: 11,
+                            fontFamily: 'monospace',
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+          // Status bar
+          Container(
+            padding: const EdgeInsets.all(4),
+            decoration: BoxDecoration(
+              color: Colors.grey.shade800,
+            ),
+            child: Row(
+              children: [
+                Text(
+                  '${loggingState.filteredEntries.length} / ${loggingState.entries.length} entries',
+                  style: const TextStyle(color: Colors.grey, fontSize: 10),
+                ),
+                const Spacer(),
+                if (loggingState.filterText != null && loggingState.filterText!.isNotEmpty)
+                  Text(
+                    'Filtered by: "${loggingState.filterText}"',
+                    style: const TextStyle(color: Colors.yellow, fontSize: 10),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _getLevelColor(LogLevel level) {
+    switch (level) {
+      case LogLevel.info:
+        return Colors.green;
+      case LogLevel.warning:
+        return Colors.orange;
+      case LogLevel.error:
+        return Colors.red;
+      case LogLevel.debug:
+        return Colors.grey;
+      case LogLevel.network:
+        return Colors.blue;
+    }
+  }
+
+  void _copyLogsToClipboard(LoggingState loggingState) {
+    final logs = loggingState.filteredEntries.map((e) => e.toString()).join('\n');
+    Clipboard.setData(ClipboardData(text: logs));
+  }
+}
+
+class LoggingToggleButton extends ConsumerWidget {
+  const LoggingToggleButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final loggingState = ref.watch(loggingProvider);
+    final loggingNotifier = ref.read(loggingProvider.notifier);
+
+    return IconButton(
+      icon: Icon(
+        Icons.terminal,
+        color: loggingState.isVisible ? Colors.cyan : Colors.grey,
+      ),
+      onPressed: loggingNotifier.toggleVisibility,
+      tooltip: loggingState.isVisible ? 'Hide Debug Console' : 'Show Debug Console',
+    );
+  }
+}

--- a/lib/src/mods/components/sidebar.dart
+++ b/lib/src/mods/components/sidebar.dart
@@ -17,6 +17,7 @@ import 'package:tts_mod_vault/src/state/provider.dart'
         directoriesProvider,
         importBackupProvider,
         loaderProvider,
+        loggingProvider,
         selectedPageProvider,
         settingsProvider;
 import 'package:tts_mod_vault/src/utils.dart'
@@ -202,6 +203,15 @@ class Sidebar extends HookConsumerWidget {
                     context: context,
                     builder: (context) => SettingsDialog(),
                   ),
+                ),
+                _SidebarItem(
+                  icon: Icons.terminal,
+                  label: 'Debug Console',
+                  isExpanded: isHovered.value,
+                  isDisabled: false,
+                  onPressed: () => ref
+                      .read(loggingProvider.notifier)
+                      .toggleVisibility(),
                 ),
               ],
             ),

--- a/lib/src/mods/mods_page.dart
+++ b/lib/src/mods/mods_page.dart
@@ -17,6 +17,8 @@ import 'package:tts_mod_vault/src/mods/components/components.dart'
         CustomTooltip;
 import 'package:tts_mod_vault/src/mods/components/filter_button.dart'
     show FilterButton;
+import 'package:tts_mod_vault/src/logging/logging_console.dart'
+    show LoggingConsole;
 import 'package:tts_mod_vault/src/state/provider.dart'
     show
         loadingMessageProvider,
@@ -114,7 +116,7 @@ class ModsColumn extends ConsumerWidget {
             child: ModsView(),
           ),
         ),
-        //  LogPanel(),
+        const LoggingConsole(),
         BulkActionsProgressBar(),
       ],
     );

--- a/lib/src/state/logging/logging.dart
+++ b/lib/src/state/logging/logging.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart' show debugPrint;
+import 'package:hooks_riverpod/hooks_riverpod.dart' show Ref, StateNotifier;
+import 'package:tts_mod_vault/src/state/logging/logging_state.dart'
+    show LogEntry, LogLevel, LoggingState;
+
+class LoggingNotifier extends StateNotifier<LoggingState> {
+  final Ref ref;
+
+  LoggingNotifier(this.ref) : super(const LoggingState());
+
+  void addLog(LogLevel level, String message, {String? category, Map<String, dynamic>? metadata}) {
+    final entry = LogEntry(
+      timestamp: DateTime.now(),
+      level: level,
+      message: message,
+      category: category,
+      metadata: metadata,
+    );
+
+    // Also print to debug console
+    debugPrint(entry.toString());
+
+    // Add to state and maintain max entries limit
+    final newEntries = [...state.entries, entry];
+    if (newEntries.length > state.maxEntries) {
+      newEntries.removeRange(0, newEntries.length - state.maxEntries);
+    }
+
+    state = state.copyWith(entries: newEntries);
+  }
+
+  void info(String message, {String? category, Map<String, dynamic>? metadata}) {
+    addLog(LogLevel.info, message, category: category, metadata: metadata);
+  }
+
+  void warning(String message, {String? category, Map<String, dynamic>? metadata}) {
+    addLog(LogLevel.warning, message, category: category, metadata: metadata);
+  }
+
+  void error(String message, {String? category, Map<String, dynamic>? metadata}) {
+    addLog(LogLevel.error, message, category: category, metadata: metadata);
+  }
+
+  void debug(String message, {String? category, Map<String, dynamic>? metadata}) {
+    addLog(LogLevel.debug, message, category: category, metadata: metadata);
+  }
+
+  void network(String message, {String? category, Map<String, dynamic>? metadata}) {
+    addLog(LogLevel.network, message, category: category, metadata: metadata);
+  }
+
+  void logHttpRequest(String method, String url, {int? statusCode, String? error}) {
+    final message = statusCode != null
+        ? '$method $url → $statusCode'
+        : error != null
+        ? '$method $url → ERROR: $error'
+        : '$method $url';
+
+    final level = error != null
+        ? LogLevel.error
+        : (statusCode != null && statusCode >= 400)
+        ? LogLevel.warning
+        : LogLevel.network;
+
+    addLog(level, message,
+        category: 'HTTP',
+        metadata: {
+          'method': method,
+          'url': url,
+          if (statusCode != null) 'statusCode': statusCode,
+          if (error != null) 'error': error,
+        });
+  }
+
+  void logDownloadStart(String url, String fileName) {
+    addLog(LogLevel.info, 'Starting download: $fileName',
+        category: 'Download',
+        metadata: {'url': url, 'fileName': fileName});
+  }
+
+  void logDownloadComplete(String fileName, {int? size}) {
+    final sizeText = size != null ? ' (${(size / 1024 / 1024).toStringAsFixed(2)} MB)' : '';
+    addLog(LogLevel.info, 'Download completed: $fileName$sizeText',
+        category: 'Download',
+        metadata: {'fileName': fileName, if (size != null) 'size': size});
+  }
+
+  void logDownloadError(String fileName, String error) {
+    addLog(LogLevel.error, 'Download failed: $fileName - $error',
+        category: 'Download',
+        metadata: {'fileName': fileName, 'error': error});
+  }
+
+  void logProxyConfiguration(String? proxyUrl) {
+    if (proxyUrl != null && proxyUrl.isNotEmpty) {
+      addLog(LogLevel.info, 'Proxy configured: $proxyUrl', category: 'Network');
+    } else {
+      addLog(LogLevel.info, 'Proxy disabled', category: 'Network');
+    }
+  }
+
+  void toggleVisibility() {
+    state = state.copyWith(isVisible: !state.isVisible);
+  }
+
+  void setVisibleLevels(Set<LogLevel> levels) {
+    state = state.copyWith(visibleLevels: levels);
+  }
+
+  void setFilter(String? filter) {
+    state = state.copyWith(filterText: filter);
+  }
+
+  void clearLogs() {
+    state = state.copyWith(entries: []);
+  }
+
+  void exportLogs() {
+    info('Logs exported (${state.entries.length} entries)', category: 'System');
+    // In a real implementation, you'd save this to a file or copy to clipboard
+    // final logs = state.entries.map((e) => e.toString()).join('\n');
+  }
+}

--- a/lib/src/state/logging/logging_state.dart
+++ b/lib/src/state/logging/logging_state.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart' show Color, Colors;
+
+enum LogLevel {
+  info,
+  warning,
+  error,
+  debug,
+  network,
+}
+
+class LogEntry {
+  final DateTime timestamp;
+  final LogLevel level;
+  final String message;
+  final String? category;
+  final Map<String, dynamic>? metadata;
+
+  LogEntry({
+    required this.timestamp,
+    required this.level,
+    required this.message,
+    this.category,
+    this.metadata,
+  });
+
+  Color get color {
+    switch (level) {
+      case LogLevel.info:
+        return Colors.white;
+      case LogLevel.warning:
+        return Colors.orange;
+      case LogLevel.error:
+        return Colors.red;
+      case LogLevel.debug:
+        return Colors.grey;
+      case LogLevel.network:
+        return Colors.blue;
+    }
+  }
+
+  String get levelText {
+    switch (level) {
+      case LogLevel.info:
+        return 'INFO';
+      case LogLevel.warning:
+        return 'WARN';
+      case LogLevel.error:
+        return 'ERROR';
+      case LogLevel.debug:
+        return 'DEBUG';
+      case LogLevel.network:
+        return 'NET';
+    }
+  }
+
+  String get formattedTime {
+    return '${timestamp.hour.toString().padLeft(2, '0')}:'
+        '${timestamp.minute.toString().padLeft(2, '0')}:'
+        '${timestamp.second.toString().padLeft(2, '0')}.'
+        '${timestamp.millisecond.toString().padLeft(3, '0')}';
+  }
+
+  @override
+  String toString() {
+    final cat = category != null ? '[$category] ' : '';
+    return '$formattedTime [$levelText] $cat$message';
+  }
+}
+
+class LoggingState {
+  final List<LogEntry> entries;
+  final bool isVisible;
+  final Set<LogLevel> visibleLevels;
+  final String? filterText;
+  final int maxEntries;
+
+  const LoggingState({
+    this.entries = const [],
+    this.isVisible = false,
+    this.visibleLevels = const {
+      LogLevel.info,
+      LogLevel.warning,
+      LogLevel.error,
+      LogLevel.network,
+    },
+    this.filterText,
+    this.maxEntries = 1000,
+  });
+
+  LoggingState copyWith({
+    List<LogEntry>? entries,
+    bool? isVisible,
+    Set<LogLevel>? visibleLevels,
+    String? filterText,
+    int? maxEntries,
+  }) {
+    return LoggingState(
+      entries: entries ?? this.entries,
+      isVisible: isVisible ?? this.isVisible,
+      visibleLevels: visibleLevels ?? this.visibleLevels,
+      filterText: filterText ?? this.filterText,
+      maxEntries: maxEntries ?? this.maxEntries,
+    );
+  }
+
+  List<LogEntry> get filteredEntries {
+    var filtered = entries.where((entry) => visibleLevels.contains(entry.level));
+
+    if (filterText != null && filterText!.isNotEmpty) {
+      final filter = filterText!.toLowerCase();
+      filtered = filtered.where((entry) =>
+          entry.message.toLowerCase().contains(filter) ||
+          (entry.category?.toLowerCase().contains(filter) ?? false));
+    }
+
+    return filtered.toList();
+  }
+}

--- a/lib/src/state/provider.dart
+++ b/lib/src/state/provider.dart
@@ -31,9 +31,16 @@ import 'package:tts_mod_vault/src/state/sort_and_filter/backup_sort_and_filter.d
 import 'package:tts_mod_vault/src/state/sort_and_filter/backup_sort_and_filter_state.dart';
 import 'package:tts_mod_vault/src/state/sort_and_filter/sort_and_filter.dart';
 import 'package:tts_mod_vault/src/state/sort_and_filter/sort_and_filter_state.dart';
+import 'package:tts_mod_vault/src/state/logging/logging.dart';
+import 'package:tts_mod_vault/src/state/logging/logging_state.dart' show LoggingState;
 import 'package:tts_mod_vault/src/state/storage/storage.dart';
 
 enum AppPage { mods, backups }
+
+final loggingProvider =
+    StateNotifierProvider<LoggingNotifier, LoggingState>(
+  (ref) => LoggingNotifier(ref),
+);
 
 final logProvider = StateNotifierProvider<LogNotifier, List<LogEntry>>((ref) {
   return LogNotifier();
@@ -50,7 +57,7 @@ final filteredLogProvider =
   final lowerQuery = searchQuery.toLowerCase();
   return logs.where((entry) {
     return entry.message.toLowerCase().contains(lowerQuery) ||
-        entry.formattedTimestamp.contains(lowerQuery);
+        entry.formattedTimestamp.toLowerCase().contains(lowerQuery);
   }).toList();
 });
 


### PR DESCRIPTION
Adds a panel-based debug console accessible via the sidebar.

- LoggingNotifier/LoggingState: in-memory log with level filtering (INFO / WARN / ERROR / DEBUG / NET), text search, and 1000-entry cap
- LoggingConsole widget: shown at the bottom of the mods column, hidden by default; includes per-level filter chips, text filter, copy-to-clipboard, and clear
- Sidebar: 'Debug Console' toggle item (terminal icon) at the bottom