### PR TITLE
Show filtered mod count in toolbar (issue #54)

### DIFF
--- a/lib/src/mods/mods_page.dart
+++ b/lib/src/mods/mods_page.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart'
     show AsyncValueX, ConsumerWidget, HookConsumerWidget, WidgetRef;
+import 'package:tts_mod_vault/src/state/mods/mod_model.dart' show ModTypeEnum;
 import 'package:tts_mod_vault/src/mods/components/components.dart'
     show
         ErrorMessage,
@@ -19,6 +20,7 @@ import 'package:tts_mod_vault/src/mods/components/filter_button.dart'
     show FilterButton;
 import 'package:tts_mod_vault/src/state/provider.dart'
     show
+        filteredModsProvider,
         loadingMessageProvider,
         modsProvider,
         modsSearchQueryProvider,
@@ -69,6 +71,13 @@ class ModsColumn extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final type = ref.watch(selectedModTypeProvider);
+    final filtered = ref.watch(filteredModsProvider);
+    final modsState = ref.watch(modsProvider).valueOrNull;
+    final total = modsState == null ? 0 : switch (type) {
+      ModTypeEnum.mod => modsState.mods.length,
+      ModTypeEnum.save => modsState.saves.length,
+      ModTypeEnum.savedObject => modsState.savedObjects.length,
+    };
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -87,6 +96,21 @@ class ModsColumn extends ConsumerWidget {
               SortButton(),
               FilterButton(),
               BulkActionsMenu(),
+              if (total > 0)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Text(
+                    filtered.length == total
+                        ? '$total'
+                        : '${filtered.length} / $total',
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: filtered.length == total
+                          ? Colors.white54
+                          : Colors.white,
+                    ),
+                  ),
+                ),
               CustomTooltip(
                 message:
                     """• Left-click a ${type.label} to see assets and actions


### PR DESCRIPTION
Displays a count label next to the bulk actions menu:
- No filter active: shows total in muted white (e.g. '156')
- Filter/search active: shows 'filtered / total' in white (e.g. '42 / 156')

Reacts live to search queries, folder filters, and asset/backup status filters.