### PR TITLE
Add force re-download all assets action (issue #27)

### DIFF
--- a/lib/src/mods/components/selected_mod_actions_menu.dart
+++ b/lib/src/mods/components/selected_mod_actions_menu.dart
@@ -9,7 +9,7 @@ import 'package:tts_mod_vault/src/mods/components/url_check_results_dialog.dart'
     show UrlCheckResultsDialog;
 import 'package:tts_mod_vault/src/state/mods/mod_model.dart' show Mod;
 import 'package:tts_mod_vault/src/state/provider.dart'
-    show actionInProgressProvider, deleteAssetsProvider, modsProvider;
+    show actionInProgressProvider, deleteAssetsProvider, downloadProvider, modsProvider;
 import 'package:tts_mod_vault/src/utils.dart'
     show showSnackBar, copyToClipboard;
 import 'package:tts_mod_vault/src/state/delete_assets/delete_assets_state.dart'
@@ -91,6 +91,57 @@ class SelectedModActionsMenu extends HookConsumerWidget {
             if (context.mounted) {
               showSnackBar(context,
                   'Copied ${missingAssets.length} missing ${missingAssets.length > 1 ? 'URLs' : 'URL'} to clipboard');
+            }
+          },
+        ),
+        MenuItemButton(
+          style: MenuItemButton.styleFrom(
+            backgroundColor: Colors.white,
+            foregroundColor: Colors.black,
+          ),
+          leadingIcon: Icon(Icons.refresh, color: Colors.black),
+          child: Text('Re-download all assets',
+              style: TextStyle(color: Colors.black)),
+          onPressed: () async {
+            if (actionInProgress) return;
+
+            final hasAssets = selectedMod.getAllAssets().isNotEmpty;
+            if (!hasAssets) return;
+
+            final confirmed = await showDialog<bool>(
+              context: context,
+              builder: (ctx) => BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 2, sigmaY: 2),
+                child: AlertDialog(
+                  title: const Text('Re-download all assets?'),
+                  content: Text(
+                    'This will re-download all ${selectedMod.assetCount} assets for "${selectedMod.saveName}", overwriting existing files.\n\nContinue?',
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.of(ctx).pop(false),
+                      child: const Text('Cancel'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => Navigator.of(ctx).pop(true),
+                      child: const Text('Re-download'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+
+            if (confirmed != true) return;
+            if (!context.mounted) return;
+
+            final modsNotifier = ref.read(modsProvider.notifier);
+            final downloaded = await ref
+                .read(downloadProvider.notifier)
+                .redownloadAllFiles(selectedMod);
+            await modsNotifier.updateSelectedMod(selectedMod);
+            if (downloaded.isNotEmpty) {
+              await modsNotifier.refreshModsWithSharedAssets(downloaded,
+                  excludeJsonFileName: selectedMod.jsonFileName);
             }
           },
         ),

--- a/lib/src/state/download/download.dart
+++ b/lib/src/state/download/download.dart
@@ -131,6 +131,37 @@ class DownloadNotifier extends StateNotifier<DownloadState> {
     return allDownloaded;
   }
 
+  // MARK: Force re-download all files
+  Future<Set<String>> redownloadAllFiles(Mod mod) async {
+    ref
+        .read(logProvider.notifier)
+        .addInfo('Force re-downloading all assets for: ${mod.saveName}');
+
+    final Set<String> allDownloaded = {};
+
+    for (final (urls, type) in [
+      (mod.assetLists.assetBundles.map((e) => e.url).toList(),
+          AssetTypeEnum.assetBundle),
+      (mod.assetLists.audio.map((e) => e.url).toList(), AssetTypeEnum.audio),
+      (mod.assetLists.images.map((e) => e.url).toList(), AssetTypeEnum.image),
+      (mod.assetLists.models.map((e) => e.url).toList(), AssetTypeEnum.model),
+      (mod.assetLists.pdf.map((e) => e.url).toList(), AssetTypeEnum.pdf),
+    ]) {
+      allDownloaded.addAll(await downloadFiles(
+        modAssetListUrls: urls,
+        type: type,
+        force: true,
+      ));
+    }
+
+    ref
+        .read(logProvider.notifier)
+        .addSuccess('Force re-download completed: ${mod.saveName}');
+
+    resetState();
+    return allDownloaded;
+  }
+
   // MARK: Reset state
   void resetState() {
     state = const DownloadState();
@@ -162,6 +193,7 @@ class DownloadNotifier extends StateNotifier<DownloadState> {
     required List<String> modAssetListUrls,
     required AssetTypeEnum type,
     bool downloadingAllFiles = true,
+    bool force = false,
   }) async {
     if (modAssetListUrls.isEmpty) {
       return [];
@@ -171,12 +203,14 @@ class DownloadNotifier extends StateNotifier<DownloadState> {
       return [];
     }
 
-    final urls = modAssetListUrls.where((url) {
-      final fileName = getFileNameFromURL(url);
-      return !ref
-          .read(existingAssetListsProvider.notifier)
-          .doesAssetFileExist(fileName, type);
-    }).toList();
+    final urls = force
+        ? List<String>.from(modAssetListUrls)
+        : modAssetListUrls.where((url) {
+            final fileName = getFileNameFromURL(url);
+            return !ref
+                .read(existingAssetListsProvider.notifier)
+                .doesAssetFileExist(fileName, type);
+          }).toList();
 
     // Track successful downloads
     final List<(String, String)> successfulDownloads = [];


### PR DESCRIPTION
Adds 'Re-download all assets' to the selected mod actions menu. Downloads every asset regardless of whether it already exists on disk, replacing any corrupted or incomplete files.

- downloadFiles() gains a force: bool flag that skips the doesAssetFileExist check when true
- redownloadAllFiles() calls downloadFiles with force: true across all asset types and logs start/completion
- Menu item shows a confirmation dialog before proceeding, then refreshes shared assets in other mods as the normal download does