### PR TITLE
Remember last-used backup folder (issue #44)

### DIFF
--- a/lib/src/mods/components/single_mod_backup_dialog.dart
+++ b/lib/src/mods/components/single_mod_backup_dialog.dart
@@ -91,6 +91,22 @@ class SingleModBackupDialog extends HookConsumerWidget {
                 onPressed: effectiveFolder == null || effectiveFolder.isEmpty
                     ? null
                     : () {
+                        // Remember this folder for next time if it's a newly
+                        // selected directory (not just re-using an existing backup)
+                        final isSelectingNewFolder =
+                            !hasExistingBackup ||
+                            locationChoice.value ==
+                                BackupLocationChoice.selectNew;
+                        if (isSelectingNewFolder &&
+                            selectedFolder.value.isNotEmpty &&
+                            selectedFolder.value != backupsDir) {
+                          final dirNotifier =
+                              ref.read(directoriesProvider.notifier);
+                          dirNotifier.updateBackupsDirectory(
+                              selectedFolder.value);
+                          dirNotifier.saveDirectories();
+                        }
+
                         onConfirm.call(
                           effectiveFolder,
                           downloadMissingFirst.value,


### PR DESCRIPTION
When the user confirms a backup to a newly selected folder, that folder is now saved as the backup directory (same setting as in Settings > Folders > Backups directory). The dialog already initialises selectedFolder from backupsDir, so the saved folder is pre-populated on the next open.

Only saves when a new folder is being selected (not when replacing an existing backup at its original location), and only when the chosen folder differs from the already-configured backupsDir.