### PR TITLE
Add bulk URL check to bulk actions menu (issue #45)

### DIFF
--- a/lib/src/mods/components/bulk_actions_menu.dart
+++ b/lib/src/mods/components/bulk_actions_menu.dart
@@ -215,6 +215,20 @@ class _BulkActionsDropDownButton extends HookConsumerWidget {
             backgroundColor: Colors.white,
             foregroundColor: Colors.black,
           ),
+          leadingIcon: Icon(Icons.link, color: Colors.black),
+          child: Text('Check all URLs', style: TextStyle(color: Colors.black)),
+          onPressed: () {
+            if (actionInProgress) return;
+            ref
+                .read(bulkActionsProvider.notifier)
+                .checkUrlsAllMods(ref.read(filteredModsProvider));
+          },
+        ),
+        MenuItemButton(
+          style: MenuItemButton.styleFrom(
+            backgroundColor: Colors.white,
+            foregroundColor: Colors.black,
+          ),
           leadingIcon: Icon(Icons.edit, color: Colors.black),
           child: Text('Update all URLs', style: TextStyle(color: Colors.black)),
           onPressed: () {

--- a/lib/src/state/bulk_actions/bulk_actions.dart
+++ b/lib/src/state/bulk_actions/bulk_actions.dart
@@ -542,6 +542,53 @@ class BulkActionsNotifier extends StateNotifier<BulkActionsState> {
     }
   }
 
+  // MARK: Check URLs
+  Future<void> checkUrlsAllMods(List<Mod> mods) async {
+    ref
+        .read(logProvider.notifier)
+        .addInfo('Starting bulk URL check for ${mods.length} mods');
+
+    state = state.copyWith(
+      status: BulkActionsStatusEnum.checkUrlsAll,
+      totalModNumber: mods.length,
+    );
+
+    final downloadNotifier = ref.read(downloadProvider.notifier);
+    final modsNotifier = ref.read(modsProvider.notifier);
+    int withInvalid = 0;
+
+    for (int i = 0; i < mods.length; i++) {
+      if (state.cancelledBulkAction) break;
+
+      await Future.delayed(Duration.zero);
+
+      final mod = mods[i];
+      state = state.copyWith(
+        currentModNumber: i + 1,
+        statusMessage:
+            'Checking URLs for "${mod.saveName}" (${i + 1}/${state.totalModNumber})',
+      );
+
+      await downloadNotifier.checkModUrlsLive(mod);
+
+      // Read the updated mod to see if it has invalid URLs
+      final updated = await modsNotifier.updateSelectedMod(mod);
+      if (updated.invalidUrls?.isNotEmpty ?? false) withInvalid++;
+    }
+
+    if (!state.cancelledBulkAction) {
+      final summary = withInvalid == 0
+          ? 'All URLs valid across ${mods.length} mods'
+          : '$withInvalid / ${mods.length} mods have invalid URLs';
+
+      withInvalid == 0
+          ? ref.read(logProvider.notifier).addSuccess(summary)
+          : ref.read(logProvider.notifier).addWarning(summary);
+    }
+
+    _resetState();
+  }
+
   // MARK: Import
   Future<void> importBackups({String? filePath}) async {
     state = state.copyWith(
@@ -652,7 +699,19 @@ class BulkActionsNotifier extends StateNotifier<BulkActionsState> {
       case BulkActionsStatusEnum.deleteAssetsAll:
         _cancelDeleteAssetsAll();
         break;
+
+      case BulkActionsStatusEnum.checkUrlsAll:
+        _cancelCheckUrlsAll();
+        break;
     }
+  }
+
+  void _cancelCheckUrlsAll() {
+    ref.read(downloadProvider.notifier).cancelAllDownloads();
+    state = state.copyWith(
+      cancelledBulkAction: true,
+      statusMessage: 'Cancelling URL check',
+    );
   }
 
   void _cancelDownloadAll() {

--- a/lib/src/state/bulk_actions/bulk_actions_state.dart
+++ b/lib/src/state/bulk_actions/bulk_actions_state.dart
@@ -6,7 +6,8 @@ enum BulkActionsStatusEnum {
   downloadAndBackupAll,
   updateModsAll,
   importingBackups,
-  deleteAssetsAll;
+  deleteAssetsAll,
+  checkUrlsAll;
 }
 
 enum BulkBackupBehaviorEnum {


### PR DESCRIPTION
'Check all URLs' in the bulk actions menu runs checkModUrlsLive on every visible (filtered) mod in sequence, updating each mod's invalid-URL list as it goes.

- BulkActionsStatusEnum: new checkUrlsAll value
- BulkActionsNotifier.checkUrlsAllMods: iterates mods, tracks progress, logs summary (N / total mods have invalid URLs)
- Cancel: stops between mods and cancels any in-flight URL check via the existing download cancel-token mechanism
- Results: per-mod invalidUrls updated in state (visible in the mod list), plus a log panel summary on completion