### PR TITLE
Fix asset URLs without a TLD being silently ignored (issue #53)

### DIFF
--- a/lib/src/state/mods/mods_isolates.dart
+++ b/lib/src/state/mods/mods_isolates.dart
@@ -18,7 +18,9 @@ import 'package:tts_mod_vault/src/utils.dart'
     show getFileNameFromURL, newSteamUserContentUrl, oldCloudUrl;
 
 final urlRegex = RegExp(
-  r'(?:[a-zA-Z]+:\/\/)?[a-zA-Z0-9.-]+\.[a-z]{2,}(?:\/[^{}"]*)?',
+  // Scheme-bearing URLs (https://something) are valid in TTS even without a TLD.
+  // Scheme-less URLs still require a TLD-like domain (e.g. steamusercontent-a.akamaihd.net/...).
+  r'[a-zA-Z]+:\/\/[^{}"\s]+|[a-zA-Z0-9.-]+\.[a-z]{2,}(?:\/[^{}"]*)?',
   caseSensitive: false,
 );
 final nicknameRegex = RegExp(r'"Nickname"\s*:\s*"([^"]*)"');


### PR DESCRIPTION
TTS treats 'https://something' (no dot/TLD in the hostname) as a valid asset URL. The urlRegex used in _processUrl required a TLD (\.[a-z]{2,}), so such URLs passed the key-based capture step but were silently dropped when urlRegex.allMatches found no match.

Fix: replace the single pattern with an alternation:
  1. scheme-bearing URLs  -> [a-zA-Z]+://[^{}"\s]+  (no TLD needed)
  2. scheme-less URLs     -> keep existing TLD-required pattern

All existing URL formats (Steam CDN, multi-URL {en}//{fr} prefixes, normal https:// URLs) continue to match identically.