### PR TITLE
Show action buttons for asset-less utility mods (issue #51)

### DIFF
--- a/lib/src/mods/components/selected_mod_view.dart
+++ b/lib/src/mods/components/selected_mod_view.dart
@@ -496,9 +496,7 @@ class _SelectedModViewComponent extends HookConsumerWidget {
             ? DownloadProgressBar()
             : backupStatus != BackupStatusEnum.idle
                 ? BackupProgressBar()
-                : listItems.isNotEmpty
-                    ? SelectedModActionButtons(selectedMod: selectedMod)
-                    : const SizedBox.shrink()
+                : SelectedModActionButtons(selectedMod: selectedMod)
       ],
     );
   }


### PR DESCRIPTION
SelectedModActionButtons was hidden when listItems was empty, which is the case for utility mods that contain only scripts and no downloadable asset files. The Backup and Actions menu buttons were therefore unreachable for these mods.

Remove the listItems.isNotEmpty guard — the buttons are always relevant. The Download button already disables itself when there are no missing assets, so no behaviour change for mods with assets.